### PR TITLE
Improvements on slider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import Card from './Components/Card.js'
 import Header from './Components/Header.js'
-import DistanceSlider from './Components/DistanceSlider'
 import data from './location.json';
 
 class App extends Component {

--- a/src/App.js
+++ b/src/App.js
@@ -25,9 +25,7 @@ class App extends Component {
     this.setState({ load: this.state.load + numNewPosts });
   };
 
-  updateDistance = ratio => {
-    let maxRadius = 5;
-    let newRadius = ratio/10*maxRadius;
+  updateDistance = newRadius => {
     let newMaxLoad = this.state.locations.filter(location => location.distance <= newRadius).length;
     this.setState({ radius: newRadius, maxLoad: newMaxLoad, load: 8 });
   };
@@ -35,7 +33,7 @@ class App extends Component {
   render() {
     return (
       <Grid>
-        <Header updateDistance={this.updateDistance} />
+        <Header />
         <Body>
           {this.props.children}
         </Body>

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import Card from './Components/Card.js'
 import Header from './Components/Header.js'
 import DistanceSlider from './Components/DistanceSlider'
-
 import data from './location.json';
 
 class App extends Component {

--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,39 @@ import Card from './Components/Card.js'
 import Header from './Components/Header.js'
 import DistanceSlider from './Components/DistanceSlider'
 
+import data from './location.json';
+
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      locations: [],
+      load: 8,
+      radius: 2.5,
+      maxLoad: 0
+    }
+  }
+
+  componentWillMount = () => {
+    this.setState({ locations: data.location, maxLoad: data.location.filter(location => location.distance <= this.state.radius).length });
+  };
+
+  loadMore = () => {
+    let numNewPosts = 8
+    this.setState({ load: this.state.load + numNewPosts });
+  };
+
+  updateDistance = ratio => {
+    let maxRadius = 5;
+    let newRadius = ratio/10*maxRadius;
+    let newMaxLoad = this.state.locations.filter(location => location.distance <= newRadius).length;
+    this.setState({ radius: newRadius, maxLoad: newMaxLoad, load: 8 });
+  };
+
   render() {
     return (
       <Grid>
-        <Header/>
+        <Header updateDistance={this.updateDistance} />
         <Body>
           {this.props.children}
         </Body>

--- a/src/Components/Card.js
+++ b/src/Components/Card.js
@@ -1,7 +1,5 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import styled from 'styled-components';
-import { Redirect } from 'react-router-dom'
-import NewPage from './NewPage.js'
 
 class Card extends Component{
  // code below is from https://medium.com/@anneeb/redirecting-in-react-4de5e517354a
@@ -34,7 +32,7 @@ class Card extends Component{
     let data = this.props.propdata
     let review = "No reviews yet"
     if (data['review']){
-      review = '\"'+ data['review']+ '\"'
+      review = '"'+ data['review']+ '"'
     }
     return (
       <CardContainer>

--- a/src/Components/DistanceSlider.js
+++ b/src/Components/DistanceSlider.js
@@ -8,9 +8,9 @@ export default class DistanceSlider extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      // currentValue is the raw value of the HTML `input` element.
+      // selectedValue is the raw value of the HTML `input` element.
       // The current distance is computed from this divided by props.numberOfIncrements.
-      currentValue: props.numberOfIncrements / 2
+      selectedValue: props.numberOfIncrements / 2
     }
   }
 
@@ -25,42 +25,52 @@ export default class DistanceSlider extends Component {
   handleSlider = event => {
     const newValue = event.target.value
     this.setState({
-      currentValue: newValue
-    }, () => {
-      const newDistance = this.currentDistance()
-      this.props.handleDistanceChanged(newDistance)
+      selectedValue: newValue
     })
+  }
+
+  handleSubmit = () => {
+    const newDistance = this.currentDistance()
+    this.props.handleDistanceChanged(newDistance)
   }
 
   /// Computes the current distance being represented.
   currentDistance = () => {
-    return this.state.currentValue / this.props.numberOfIncrements * this.props.maxDistance
+    return this.state.selectedValue / this.props.numberOfIncrements * this.props.maxDistance
   }
 
   render() {
     return (
       <Container>
-        <Slider type="range" min={0} max={this.props.numberOfIncrements} value={this.state.currentValue} onChange={this.handleSlider} />
-        <Radius>Radius: {this.currentDistance()} Miles</Radius>
+        <Slider type="range" min={0} max={this.props.numberOfIncrements} value={this.state.selectedValue} onChange={this.handleSlider} />
+        <div>
+          <Button onClick={this.handleSubmit}>Apply search radius: {this.currentDistance()} Mile(s)</Button>
+        </div>
       </Container>
     )
   }
 }
 
 const Container = styled.div`
-  // grid-column: 2;
-  // position: relative;
-  // top: 50%;
-  // transform: translateY(-50%);
-  // width: 100%;
+  bottom: 0;
+  width: 100%;
   text-align: center;
+  position: fixed;
+  z-index: 5;
+  background-color: rgba(78, 42, 132, .5);
 `
 
 const Slider = styled.input`
-  width: 90%;
-  text-align: center;
+  width: 66.7%;
 `
 
-const Radius = styled.p`
-  margin: 0;
+const Button = styled.button`
+  font-size: 1em;
+  color: white;
+  background-color: #75b;
+  border: none;
+  border-radius: 0.5em;
+  padding: 0.3em;
+  font-weight: bold;
+  cursor: pointer;
 `

--- a/src/Components/DistanceSlider.js
+++ b/src/Components/DistanceSlider.js
@@ -5,62 +5,62 @@ import styled from 'styled-components'
 /// The component that lets the user select the distance for places to see.
 /// Pass a prop called handleDistanceChanged as a function to handle the new distance selected.
 export default class DistanceSlider extends Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            // currentValue is the raw value of the HTML `input` element.
-            // The current distance is computed from this divided by props.numberOfIncrements.
-            currentValue: props.numberOfIncrements / 2
-        }
+  constructor(props) {
+    super(props)
+    this.state = {
+      // currentValue is the raw value of the HTML `input` element.
+      // The current distance is computed from this divided by props.numberOfIncrements.
+      currentValue: props.numberOfIncrements / 2
     }
+  }
 
-    propTypes: {
-        handleDistanceChanged: PropTypes.func.isRequired,
-        // number of increments on the HTML `input` element.
-        numberOfIncrements: PropTypes.number.isRequired,
-        // The maximum distance that this slider can represent.
-        maxDistance: PropTypes.number.isRequired
-    }
+  propTypes: {
+    handleDistanceChanged: PropTypes.func.isRequired,
+    // number of increments on the HTML `input` element.
+    numberOfIncrements: PropTypes.number.isRequired,
+    // The maximum distance that this slider can represent.
+    maxDistance: PropTypes.number.isRequired
+  }
 
-    handleSlider = event => {
-        const newValue = event.target.value
-        this.setState({
-            currentValue: newValue
-        }, () => {
-            const newDistance = this.currentDistance()
-            this.props.handleDistanceChanged(newDistance)
-        })
-    }
+  handleSlider = event => {
+    const newValue = event.target.value
+    this.setState({
+      currentValue: newValue
+    }, () => {
+      const newDistance = this.currentDistance()
+      this.props.handleDistanceChanged(newDistance)
+    })
+  }
 
-    /// Computes the current distance being represented.
-    currentDistance = () => {
-        return this.state.currentValue / this.props.numberOfIncrements * this.props.maxDistance
-    }
+  /// Computes the current distance being represented.
+  currentDistance = () => {
+    return this.state.currentValue / this.props.numberOfIncrements * this.props.maxDistance
+  }
 
-    render() {
-        return (
-            <Container>
-                <Slider type="range" min={0} max={this.props.numberOfIncrements} value={this.state.currentValue} onChange={this.handleSlider} />
-                <Radius>Radius: {this.currentDistance()} Miles</Radius>
-            </Container>
-        )
-    }
+  render() {
+    return (
+      <Container>
+        <Slider type="range" min={0} max={this.props.numberOfIncrements} value={this.state.currentValue} onChange={this.handleSlider} />
+        <Radius>Radius: {this.currentDistance()} Miles</Radius>
+      </Container>
+    )
+  }
 }
 
 const Container = styled.div`
-    // grid-column: 2;
-    // position: relative;
-    // top: 50%;
-    // transform: translateY(-50%);
-    // width: 100%;
-    text-align: center;
+  // grid-column: 2;
+  // position: relative;
+  // top: 50%;
+  // transform: translateY(-50%);
+  // width: 100%;
+  text-align: center;
 `
 
 const Slider = styled.input`
-    width: 90%;
-    text-align: center;
+  width: 90%;
+  text-align: center;
 `
 
 const Radius = styled.p`
-    margin: 0;
+  margin: 0;
 `

--- a/src/Components/DistanceSlider.js
+++ b/src/Components/DistanceSlider.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 /// The component that lets the user select the distance for places to see.
 /// Pass a prop called handleDistanceChanged as a function to handle the new distance selected.
@@ -27,7 +28,27 @@ export default class DistanceSlider extends Component {
 
     render() {
         return (
-            <input type="range" min={0} max={this._maxDistance} value={this.state.currentDistance} onChange={this.handleSlider} />
+            <Container>
+                <Slider type="range" min={0} max={this._maxDistance} value={this.state.currentDistance} onChange={this.handleSlider} />
+                <Radius>Radius: {this.state.currentDistance} Miles</Radius>
+            </Container>
         )
     }
 }
+
+const Container = styled.div`
+    grid-column: 2;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+    text-align: center;
+`
+
+const Slider = styled.input`
+    width: 100%;
+`
+
+const Radius = styled.p`
+    margin: 0;
+`

--- a/src/Components/DistanceSlider.js
+++ b/src/Components/DistanceSlider.js
@@ -8,45 +8,57 @@ export default class DistanceSlider extends Component {
     constructor(props) {
         super(props)
         this.state = {
-            currentDistance: this._maxDistance / 2
+            // currentValue is the raw value of the HTML `input` element.
+            // The current distance is computed from this divided by props.numberOfIncrements.
+            currentValue: props.numberOfIncrements / 2
         }
     }
 
     propTypes: {
-        handleDistanceChanged: PropTypes.func.isRequired
+        handleDistanceChanged: PropTypes.func.isRequired,
+        // number of increments on the HTML `input` element.
+        numberOfIncrements: PropTypes.number.isRequired,
+        // The maximum distance that this slider can represent.
+        maxDistance: PropTypes.number.isRequired
     }
 
-    _maxDistance = 10
-
     handleSlider = event => {
-        const newDistance = event.target.value
+        const newValue = event.target.value
         this.setState({
-            currentDistance: newDistance
+            currentValue: newValue
+        }, () => {
+            const newDistance = this.currentDistance()
+            this.props.handleDistanceChanged(newDistance)
         })
-        this.props.handleDistanceChanged(newDistance)
+    }
+
+    /// Computes the current distance being represented.
+    currentDistance = () => {
+        return this.state.currentValue / this.props.numberOfIncrements * this.props.maxDistance
     }
 
     render() {
         return (
             <Container>
-                <Slider type="range" min={0} max={this._maxDistance} value={this.state.currentDistance} onChange={this.handleSlider} />
-                <Radius>Radius: {this.state.currentDistance} Miles</Radius>
+                <Slider type="range" min={0} max={this.props.numberOfIncrements} value={this.state.currentValue} onChange={this.handleSlider} />
+                <Radius>Radius: {this.currentDistance()} Miles</Radius>
             </Container>
         )
     }
 }
 
 const Container = styled.div`
-    grid-column: 2;
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 100%;
+    // grid-column: 2;
+    // position: relative;
+    // top: 50%;
+    // transform: translateY(-50%);
+    // width: 100%;
     text-align: center;
 `
 
 const Slider = styled.input`
-    width: 100%;
+    width: 90%;
+    text-align: center;
 `
 
 const Radius = styled.p`

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
+import DistanceSlider from './DistanceSlider'
 
 class Header extends Component {
   render() {
@@ -8,9 +9,7 @@ class Header extends Component {
         <Title>
           <TitleText>Follow <br/> My <br/> Lead</TitleText>
         </Title>
-        <Settings>
-          <Hamburger> &#9776; </Hamburger>
-        </Settings>
+        <DistanceSlider handleDistanceChanged={ratio => this.props.updateDistance(ratio)} />
       </Grid>
     );
   }
@@ -40,12 +39,6 @@ const TitleText = styled.p`
   position: relative;
   top: 50%;
   transform: translateY(-50%);
-`;
-
-const Settings = styled.div`
-  grid-column: 2;
-  width: 100%;
-  position: relative;
 `;
 
 const Hamburger = styled.p`

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import DistanceSlider from './DistanceSlider'
 
 class Header extends Component {
   render() {
@@ -9,7 +8,7 @@ class Header extends Component {
         <Title>
           <TitleText>Follow <br/> My <br/> Lead</TitleText>
         </Title>
-        {/*<DistanceSlider handleDistanceChanged={ratio => this.props.updateDistance(ratio)} />*/}
+        <Hamburger>&#9776;</Hamburger>
       </Grid>
     );
   }

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -9,7 +9,7 @@ class Header extends Component {
         <Title>
           <TitleText>Follow <br/> My <br/> Lead</TitleText>
         </Title>
-        <DistanceSlider handleDistanceChanged={ratio => this.props.updateDistance(ratio)} />
+        {/*<DistanceSlider handleDistanceChanged={ratio => this.props.updateDistance(ratio)} />*/}
       </Grid>
     );
   }

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -8,7 +8,9 @@ class Header extends Component {
         <Title>
           <TitleText>Follow <br/> My <br/> Lead</TitleText>
         </Title>
-        <Hamburger>&#9776;</Hamburger>
+        <Settings>
+          <Hamburger>&#9776;</Hamburger>
+        </Settings>
       </Grid>
     );
   }
@@ -38,6 +40,12 @@ const TitleText = styled.p`
   position: relative;
   top: 50%;
   transform: translateY(-50%);
+`;
+
+const Settings = styled.div`
+  grid-column: 2;
+  width: 100%;
+  position: relative;
 `;
 
 const Hamburger = styled.p`

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -28,9 +28,7 @@ class HomePage extends Component {
     this.setState({ load: this.state.load + numNewPosts });
   };
 
-  updateDistance = ratio => {
-    let maxRadius = 5;
-    let newRadius = ratio/10*maxRadius;
+  updateDistance = newRadius => {
     let newMaxLoad = this.state.locations.filter(location => location.distance <= newRadius).length;
     this.setState({ radius: newRadius, maxLoad: newMaxLoad, load: 8 });
   };
@@ -38,9 +36,7 @@ class HomePage extends Component {
   render() {
     return (
       <div>
-        <div>
-          <DistanceSlider handleDistanceChanged={ratio => this.updateDistance(ratio)} numberOfIncrements={10} maxDistance={5} />
-        </div>
+        <h2>Within {this.state.radius} mile(s):</h2>
         {this.state.locations
             .filter(location => location.distance <= this.state.radius)
             .slice(0, this.state.load)
@@ -51,6 +47,8 @@ class HomePage extends Component {
           ))}
           {this.state.load < this.state.maxLoad &&
             <LoadMore onClick={this.loadMore}> Load More </LoadMore>}
+          <div style={{ height: '4em' }} /> {/* Quick fix so slider doesn't block */}
+          <DistanceSlider handleDistanceChanged={this.updateDistance} numberOfIncrements={10} maxDistance={5} />
       </div>
     );
   }

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -20,7 +20,7 @@ class HomePage extends Component {
   }
 
   componentWillMount = () => {
-    this.setState({ locations: data.location, maxLoad: data.location.filter(location => location.distance <= this.state.radius).length });
+    this.setState({ locations: data.location.sort((l1, l2) => l1.distance > l2.distance), maxLoad: data.location.filter(location => location.distance <= this.state.radius).length });
   };
 
   loadMore = () => {

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -1,10 +1,7 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { Redirect } from 'react-router-dom'
 import Card from './Card.js';
-import Settings from './Settings.js';
-import Header from './Header.js';
 import DistanceSlider from './DistanceSlider'
 import data from '../location.json';
 
@@ -43,7 +40,7 @@ class HomePage extends Component {
             .filter(location => location.distance <= this.state.radius)
             .slice(0, this.state.load)
             .map((data,index) => (
-              <Link to={`/location/${data.id}`} style={{textDecoration: 'none'}}>
+              <Link to={`/location/${data.id}`} style={{textDecoration: 'none'}} key={index}>
                 <Card propdata={data}/>
               </Link>
           ))}

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -8,13 +8,15 @@ import Header from './Header.js';
 import DistanceSlider from './DistanceSlider'
 import data from '../location.json';
 
+const MAX_DISTANCE = 5
+
 class HomePage extends Component {
   constructor(props) {
     super(props);
     this.state = {
       locations: [],
       load: 8,
-      radius: 2.5,
+      radius: MAX_DISTANCE / 2,
       maxLoad: 0
     }
   }
@@ -48,7 +50,7 @@ class HomePage extends Component {
           {this.state.load < this.state.maxLoad &&
             <LoadMore onClick={this.loadMore}> Load More </LoadMore>}
           <div style={{ height: '4em' }} /> {/* Quick fix so slider doesn't block */}
-          <DistanceSlider handleDistanceChanged={this.updateDistance} numberOfIncrements={10} maxDistance={5} />
+          <DistanceSlider handleDistanceChanged={this.updateDistance} numberOfIncrements={10} maxDistance={MAX_DISTANCE} />
       </div>
     );
   }

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -5,7 +5,7 @@ import { Redirect } from 'react-router-dom'
 import Card from './Card.js';
 import Settings from './Settings.js';
 import Header from './Header.js';
-import DistanceSlider from './DistanceSlider';
+import DistanceSlider from './DistanceSlider'
 import data from '../location.json';
 
 class HomePage extends Component {
@@ -17,8 +17,6 @@ class HomePage extends Component {
       radius: 2.5,
       maxLoad: 0
     }
-
-    this.updateDistance = this.updateDistance.bind(this);
   }
 
   componentWillMount = () => {
@@ -40,6 +38,9 @@ class HomePage extends Component {
   render() {
     return (
       <div>
+        <div>
+          <DistanceSlider handleDistanceChanged={ratio => this.updateDistance(ratio)} numberOfIncrements={10} maxDistance={5} />
+        </div>
         {this.state.locations
             .filter(location => location.distance <= this.state.radius)
             .slice(0, this.state.load)
@@ -50,8 +51,6 @@ class HomePage extends Component {
           ))}
           {this.state.load < this.state.maxLoad &&
             <LoadMore onClick={this.loadMore}> Load More </LoadMore>}
-          <DistanceSlider handleDistanceChanged={ratio => this.updateDistance(ratio)} />
-          Radius: {this.state.radius} Miles
       </div>
     );
   }

--- a/src/Components/NewPage.js
+++ b/src/Components/NewPage.js
@@ -1,6 +1,5 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import styled from 'styled-components';
-import { Redirect } from 'react-router-dom'
 import { Link } from 'react-router-dom';
 import data from '../location.json';
 
@@ -13,14 +12,14 @@ class NewPage extends Component{
   }
 
   componentWillMount = () => {
-    this.setState({ location: data.location.filter(location => location.id == this.props.match.params.id)[0]});
+    this.setState({ location: data.location.filter(location => location.id === this.props.match.params.id)[0]});
   };
 
   render(){
-    let google_link = "https:\/\/www.google.com/maps/search/?api=1&query=" + this.state.location.location.replace(/ /g, "+");
+    let google_link = "https://www.google.com/maps/search/?api=1&query=" + this.state.location.location.replace(/ /g, "+");
     let review = "No reviews yet"
     if (this.state.location.review){
-      review = '\"'+ this.state.location.review + '\"'
+      review = '"'+ this.state.location.review + '"'
     }
     console.log(google_link);
     return(


### PR DESCRIPTION
Move slider to the top of the page.

<img width="354" alt="image" src="https://user-images.githubusercontent.com/7534708/51302850-3b108400-19f9-11e9-9ccd-b8bd10f9e6af.png">

This no longer actually puts the slider in the header because of the way we're loading the location JSON now, but this PR implements the following changes:

UX changes:
- The slider is on the bottom of the page and is fixed on-screen when scrolling.
- You now need to press a button to apply a new search radius, instead of the content changing when you're sliding.
- It displays the search radius that has been applied.
- All locations are pre-sorted once, by distance.

Technical changes:
- The `DistanceSlider` component is responsible for calculating the radius itself, and passes that to the containing component. Previously, the container in `HomePage` did the calculation from the input's "ratio", which got a little messy.
- `DistanceSlider` can now be configured to have different increments or maximum distances.
- Fix misc. compile-time and runtime warnings.